### PR TITLE
feature: 커스텀 네비게이션 바 추가

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "DWDesignKit",
+    platforms: [.iOS(.v13)],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(

--- a/Sources/DWDesignKit/Base/DWBaseNavBarViewController.swift
+++ b/Sources/DWDesignKit/Base/DWBaseNavBarViewController.swift
@@ -56,6 +56,12 @@ open class DWBaseNavBarViewController: DWBaseViewController {
         }
     }
     
+    public var navBarType: DWNavBarType = .pushed {
+        didSet {
+            navBar.barType = navBarType
+        }
+    }
+    
     open override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -74,7 +80,7 @@ open class DWBaseNavBarViewController: DWBaseViewController {
         navTitle = title
         navBarBackgroundColor = backgroundColor
         navBar.barHeight = height
-        navBar.configBarButtons(type)
+        navBar.barType = type
         
         if view.subviews.contains(navBar) { return }
         

--- a/Sources/DWDesignKit/Base/DWBaseNavBarViewController.swift
+++ b/Sources/DWDesignKit/Base/DWBaseNavBarViewController.swift
@@ -1,0 +1,92 @@
+//
+//  DWBaseNavViewController.swift
+//
+//
+//  Created by Eunbee Kang on 3/21/24.
+//
+
+import UIKit
+
+open class DWBaseNavBarViewController: DWBaseViewController {
+    
+    private var upperBackgroundView: UIView = {
+        let view = UIView()
+        
+        return view
+    }()
+    
+    private var navBar = DWNavBarView()
+    
+    // MARK: - Public properties for custom navigation bar
+    
+    public var navTitle: String = "" {
+        didSet {
+            navBar.titleText = navTitle
+        }
+    }
+    
+    public var navTitleColor: UIColor = .black {
+        didSet {
+            navBar.titleColor = navTitleColor
+        }
+    }
+    
+    public var navButtonColor: UIColor = .black {
+        didSet {
+            navBar.buttonColor = navButtonColor
+        }
+    }
+    
+    public var dwNavBarBackgroundColor: UIColor? {
+        didSet {
+            upperBackgroundView.backgroundColor = dwNavBarBackgroundColor
+            navBar.backgroundColor = dwNavBarBackgroundColor
+        }
+    }
+    
+    public func addCustomNavBarView(
+        with type: DWNavBarType = .pushed,
+        title: String = "",
+        backgroundColor: UIColor = .white,
+        height: CGFloat = 44
+    ) {
+        setNativeNavigation()
+        
+        navTitle = title
+        dwNavBarBackgroundColor = backgroundColor
+        navBar.barHeight = height
+        navBar.configBarButtons(type)
+        
+        view.addSubview(upperBackgroundView)
+        view.addSubview(navBar)
+        
+        navBar.translatesAutoresizingMaskIntoConstraints = false
+        upperBackgroundView.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            upperBackgroundView.topAnchor.constraint(equalTo: view.topAnchor),
+            upperBackgroundView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            upperBackgroundView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            upperBackgroundView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            
+            navBar.topAnchor.constraint(equalTo: upperBackgroundView.bottomAnchor),
+            navBar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            navBar.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+    }
+    
+    public func removeCustomNavBarView() {
+        if view.subviews.contains(upperBackgroundView) {
+            upperBackgroundView.removeFromSuperview()
+        }
+        if view.subviews.contains(navBar) {
+            navBar.removeFromSuperview()
+        }
+    }
+    
+    // MARK: - Private helpers
+    
+    private func setNativeNavigation() {
+        navigationController?.isNavigationBarHidden = true
+    }
+}

--- a/Sources/DWDesignKit/Base/DWBaseNavBarViewController.swift
+++ b/Sources/DWDesignKit/Base/DWBaseNavBarViewController.swift
@@ -17,6 +17,12 @@ open class DWBaseNavBarViewController: DWBaseViewController {
     
     private var navBar = DWNavBarView()
     
+    public var contentView: UIView  = {
+        let view = UIView()
+        
+        return view
+    }()
+    
     // MARK: - Public properties for custom navigation bar
     
     public var navTitle: String = "" {
@@ -37,25 +43,40 @@ open class DWBaseNavBarViewController: DWBaseViewController {
         }
     }
     
-    public var dwNavBarBackgroundColor: UIColor? {
+    public var navBarBackgroundColor: UIColor? {
         didSet {
-            upperBackgroundView.backgroundColor = dwNavBarBackgroundColor
-            navBar.backgroundColor = dwNavBarBackgroundColor
+            upperBackgroundView.backgroundColor = navBarBackgroundColor
+            navBar.backgroundColor = navBarBackgroundColor
         }
+    }
+    
+    public var navBarHeight: CGFloat = 44 {
+        didSet {
+            navBar.barHeight = navBarHeight
+        }
+    }
+    
+    open override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        addCustomNavBarView()
+        setContentView()
     }
     
     public func addCustomNavBarView(
         with type: DWNavBarType = .pushed,
         title: String = "",
-        backgroundColor: UIColor = .white,
+        backgroundColor: UIColor = .clear,
         height: CGFloat = 44
     ) {
         setNativeNavigation()
         
         navTitle = title
-        dwNavBarBackgroundColor = backgroundColor
+        navBarBackgroundColor = backgroundColor
         navBar.barHeight = height
         navBar.configBarButtons(type)
+        
+        if view.subviews.contains(navBar) { return }
         
         view.addSubview(upperBackgroundView)
         view.addSubview(navBar)
@@ -76,6 +97,10 @@ open class DWBaseNavBarViewController: DWBaseViewController {
     }
     
     public func removeCustomNavBarView() {
+        contentView.removeFromSuperview()
+        view.addSubview(contentView)
+        setContentViewConstraints(withTopAnchor: view.topAnchor)
+        
         if view.subviews.contains(upperBackgroundView) {
             upperBackgroundView.removeFromSuperview()
         }
@@ -88,5 +113,20 @@ open class DWBaseNavBarViewController: DWBaseViewController {
     
     private func setNativeNavigation() {
         navigationController?.isNavigationBarHidden = true
+    }
+    
+    private func setContentView() {
+        view.addSubview(contentView)
+        contentView.translatesAutoresizingMaskIntoConstraints = false
+        setContentViewConstraints(withTopAnchor: navBar.bottomAnchor)
+    }
+    
+    private func setContentViewConstraints(withTopAnchor anchor: NSLayoutYAxisAnchor) {
+        NSLayoutConstraint.activate([
+            contentView.topAnchor.constraint(equalTo: anchor),
+            contentView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            contentView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            contentView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
     }
 }

--- a/Sources/DWDesignKit/Base/DWBaseTableViewCell.swift
+++ b/Sources/DWDesignKit/Base/DWBaseTableViewCell.swift
@@ -12,6 +12,8 @@ open class DWBaseTableViewCell: UITableViewCell {
     override public init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         
+        selectionStyle = .none
+        
         configViewHierarchy()
         configLayoutConstraints()
         configViewSettings()

--- a/Sources/DWDesignKit/Base/DWBaseViewController.swift
+++ b/Sources/DWDesignKit/Base/DWBaseViewController.swift
@@ -26,6 +26,8 @@ open class DWBaseViewController: UIViewController {
     override open func viewDidLoad() {
         super.viewDidLoad()
         
+        view.backgroundColor = .systemBackground
+        
         configViewHierarchy()
         configLayoutConstraints()
         configViewSettings()

--- a/Sources/DWDesignKit/Base/DWBaseViewController.swift
+++ b/Sources/DWDesignKit/Base/DWBaseViewController.swift
@@ -14,40 +14,6 @@ open class DWBaseViewController: UIViewController {
     
     public let disposeBag = DisposeBag()
     
-    // MARK: - For custom navigation bar
-    
-    private var upperBackgroundView: UIView = {
-        let view = UIView()
-        
-        return view
-    }()
-    
-    public var dwNavBar = DWNavBarView()
-    
-    public var navTitle: String? {
-        didSet {
-            title = navTitle
-        }
-    }
-    
-    public var dwNavBarBackgroundColor: UIColor? {
-        didSet {
-            upperBackgroundView.backgroundColor = dwNavBarBackgroundColor
-            dwNavBar.backgroundColor = dwNavBarBackgroundColor
-        }
-    }
-    
-    // MARK: - LifeCycle
-    
-    override open func viewDidLoad() {
-        super.viewDidLoad()
-        
-        configViewHierarchy()
-        configLayoutConstraints()
-        configViewSettings()
-        configRx()
-    }
-    
     public override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
     }
@@ -57,43 +23,13 @@ open class DWBaseViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
-    public func addCustomNavBarView(
-        with type: DWNavBarType = .pushed,
-        title: String = "",
-        backgroundColor: UIColor = .white,
-        height: CGFloat = 44
-    ) {
-        navigationController?.isNavigationBarHidden = true
+    override open func viewDidLoad() {
+        super.viewDidLoad()
         
-        setCustomNavBarTitle(title)
-        dwNavBarBackgroundColor = backgroundColor
-        dwNavBar.barHeight = height
-        dwNavBar.configBarButtons(type)
-        
-        view.addSubview(upperBackgroundView)
-        view.addSubview(dwNavBar)
-        
-        dwNavBar.translatesAutoresizingMaskIntoConstraints = false
-        upperBackgroundView.translatesAutoresizingMaskIntoConstraints = false
-        
-        NSLayoutConstraint.activate([
-            upperBackgroundView.topAnchor.constraint(equalTo: view.topAnchor),
-            upperBackgroundView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            upperBackgroundView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            upperBackgroundView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            
-            dwNavBar.topAnchor.constraint(equalTo: upperBackgroundView.bottomAnchor),
-            dwNavBar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            dwNavBar.trailingAnchor.constraint(equalTo: view.trailingAnchor)
-        ])
-    }
-    
-    public func removeCustomNavBarView() {
-        dwNavBar.removeFromSuperview()
-    }
-    
-    public func setCustomNavBarTitle(_ title: String) {
-        dwNavBar.titleText = title
+        configViewHierarchy()
+        configLayoutConstraints()
+        configViewSettings()
+        configRx()
     }
     
     open func configViewHierarchy() { }

--- a/Sources/DWDesignKit/Base/DWBaseViewController.swift
+++ b/Sources/DWDesignKit/Base/DWBaseViewController.swift
@@ -1,6 +1,6 @@
 //
-//  File.swift
-//  
+//  DWBaseViewController.swift
+//
 //
 //  Created by Eunbee Kang on 3/18/24.
 //
@@ -13,6 +13,31 @@ import RxSwift
 open class DWBaseViewController: UIViewController {
     
     public let disposeBag = DisposeBag()
+    
+    // MARK: - For custom navigation bar
+    
+    private var upperBackgroundView: UIView = {
+        let view = UIView()
+        
+        return view
+    }()
+    
+    public var dwNavBar = DWNavBarView()
+    
+    public var navTitle: String? {
+        didSet {
+            title = navTitle
+        }
+    }
+    
+    public var dwNavBarBackgroundColor: UIColor? {
+        didSet {
+            upperBackgroundView.backgroundColor = dwNavBarBackgroundColor
+            dwNavBar.backgroundColor = dwNavBarBackgroundColor
+        }
+    }
+    
+    // MARK: - LifeCycle
     
     override open func viewDidLoad() {
         super.viewDidLoad()
@@ -30,6 +55,45 @@ open class DWBaseViewController: UIViewController {
     @available(*, unavailable)
     required public init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    public func addCustomNavBarView(
+        with type: DWNavBarType = .pushed,
+        title: String = "",
+        backgroundColor: UIColor = .white,
+        height: CGFloat = 44
+    ) {
+        navigationController?.isNavigationBarHidden = true
+        
+        setCustomNavBarTitle(title)
+        dwNavBarBackgroundColor = backgroundColor
+        dwNavBar.barHeight = height
+        dwNavBar.configBarButtons(type)
+        
+        view.addSubview(upperBackgroundView)
+        view.addSubview(dwNavBar)
+        
+        dwNavBar.translatesAutoresizingMaskIntoConstraints = false
+        upperBackgroundView.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            upperBackgroundView.topAnchor.constraint(equalTo: view.topAnchor),
+            upperBackgroundView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            upperBackgroundView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            upperBackgroundView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            
+            dwNavBar.topAnchor.constraint(equalTo: upperBackgroundView.bottomAnchor),
+            dwNavBar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            dwNavBar.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+    }
+    
+    public func removeCustomNavBarView() {
+        dwNavBar.removeFromSuperview()
+    }
+    
+    public func setCustomNavBarTitle(_ title: String) {
+        dwNavBar.titleText = title
     }
     
     open func configViewHierarchy() { }

--- a/Sources/DWDesignKit/Component/DWNavBar.swift
+++ b/Sources/DWDesignKit/Component/DWNavBar.swift
@@ -1,0 +1,146 @@
+//
+//  DWNavBar.swift
+//
+//
+//  Created by Eunbee Kang on 3/19/24.
+//
+
+import UIKit
+
+public enum DWNavBarType {
+    case pushed
+    case leftCloseButton
+    case rightCloseButton
+    
+    var imageConfig: UIImage.SymbolConfiguration {
+        switch self {
+        case .pushed:
+            return UIImage.SymbolConfiguration(pointSize: 22, weight: .semibold)
+            
+        case .leftCloseButton:
+            return UIImage.SymbolConfiguration(pointSize: 17, weight: .semibold)
+            
+        case .rightCloseButton:
+            return UIImage.SymbolConfiguration(pointSize: 17, weight: .semibold)
+        }
+    }
+}
+
+public final class DWNavBarView: DWBaseView {
+    
+    private var leftNavBarItemStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.alignment = .center
+        stackView.distribution = .fill
+        stackView.spacing = 8
+        
+        return stackView
+    }()
+    
+    private var rightNavBarItemStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.alignment = .center
+        stackView.distribution = .fill
+        stackView.spacing = 8
+        
+        return stackView
+    }()
+    
+    public var leftBarButton: UIButton = {
+        let button = UIButton()
+        
+        return button
+    }()
+    
+    public var rightBarButton: UIButton = {
+        let button = UIButton()
+        
+        return button
+    }()
+    
+    private var titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .preferredFont(forTextStyle: .headline)
+        label.textColor = .black
+        label.textAlignment = .center
+        
+        return label
+    }()
+    
+    public var titleText: String? {
+        didSet {
+            titleLabel.text = titleText
+        }
+    }
+    
+    public var titleColor: UIColor? {
+        didSet {
+            titleLabel.textColor = titleColor
+        }
+    }
+    
+    public var buttonColor: UIColor? {
+        didSet {
+            leftBarButton.tintColor = buttonColor
+            rightBarButton.tintColor = buttonColor
+        }
+    }
+    
+    public var barHeight: CGFloat = 44 {
+        didSet {
+            if barHeight < 44 { barHeight = 44 }
+            heightAnchor.constraint(equalToConstant: barHeight).isActive = true
+        }
+    }
+    
+    func configBarButtons(_ type: DWNavBarType) {
+        let config = type.imageConfig
+        
+        switch type {
+        case .pushed:
+            leftBarButton.setImage(UIImage(systemName: "chevron.left", withConfiguration: config), for: .normal)
+            leftNavBarItemStackView.addArrangedSubview(leftBarButton)
+            
+        case .leftCloseButton:
+            leftBarButton.setImage(UIImage(systemName: "xmark", withConfiguration: config), for: .normal)
+            leftNavBarItemStackView.addArrangedSubview(leftBarButton)
+            
+        case .rightCloseButton:
+            rightBarButton.setImage(UIImage(systemName: "xmark", withConfiguration: config), for: .normal)
+            rightNavBarItemStackView.addArrangedSubview(rightBarButton)
+        }
+    }
+
+    public override func configViewSettings() {
+        [leftNavBarItemStackView, rightNavBarItemStackView, titleLabel].forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+    }
+    
+    public override func configViewHierarchy() {
+        addSubview(leftNavBarItemStackView)
+        addSubview(rightNavBarItemStackView)
+        addSubview(titleLabel)
+    }
+    
+    public override func configLayoutConstraints() {
+        NSLayoutConstraint.activate([
+            leftNavBarItemStackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            leftNavBarItemStackView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            leftNavBarItemStackView.topAnchor.constraint(equalTo: topAnchor),
+            leftNavBarItemStackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            
+            rightNavBarItemStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+            rightNavBarItemStackView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            rightNavBarItemStackView.topAnchor.constraint(equalTo: topAnchor),
+            rightNavBarItemStackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            
+            titleLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
+            titleLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+            titleLabel.leadingAnchor.constraint(greaterThanOrEqualTo: leftNavBarItemStackView.trailingAnchor, constant: 16),
+            titleLabel.trailingAnchor.constraint(lessThanOrEqualTo: rightNavBarItemStackView.leadingAnchor, constant: -16)
+        ])
+    }
+}

--- a/Sources/DWDesignKit/Component/DWNavBar.swift
+++ b/Sources/DWDesignKit/Component/DWNavBar.swift
@@ -29,17 +29,9 @@ final class DWNavBarView: DWBaseView {
         return stackView
     }()
     
-    var leftBarButton: UIButton = {
-        let button = UIButton()
-        
-        return button
-    }()
-    
-    var rightBarButton: UIButton = {
-        let button = UIButton()
-        
-        return button
-    }()
+    var leftBarCloseButton = DWNavBarButton(type: .leftCloseButton)
+    var rightBarCloseButton = DWNavBarButton(type: .rightCloseButton)
+    var leftBarBackButton = DWNavBarButton(type: .pushed)
     
     private var titleLabel: UILabel = {
         let label = UILabel()
@@ -64,8 +56,9 @@ final class DWNavBarView: DWBaseView {
     
     var buttonColor: UIColor? {
         didSet {
-            leftBarButton.tintColor = buttonColor
-            rightBarButton.tintColor = buttonColor
+            leftBarCloseButton.tintColor = buttonColor
+            rightBarCloseButton.tintColor = buttonColor
+            leftBarBackButton.tintColor = buttonColor
         }
     }
     
@@ -83,18 +76,40 @@ final class DWNavBarView: DWBaseView {
         }
     }
     
-    func configBarButtons(_ type: DWNavBarType) {
-        let config = UIImage.SymbolConfiguration(pointSize: type.imageSize, weight: .semibold)
-        let image = UIImage(systemName: type.systemImageName, withConfiguration: config)
-        
-        switch type {
-        case .pushed, .leftCloseButton:
-            leftBarButton.setImage(image, for: .normal)
-            leftNavBarItemStackView.addArrangedSubview(leftBarButton)
+    var barType: DWNavBarType = .pushed {
+        didSet {
+            removeBarButtons()
+            configBarButtons()
+            
+            leftStackViewLeadingConstraint = leftNavBarItemStackView.leadingAnchor.constraint(
+                equalTo: leadingAnchor, 
+                constant: barType.leadingInset
+            )
+        }
+    }
+    
+    private var leftStackViewLeadingConstraint: NSLayoutConstraint? {
+        didSet {
+            oldValue?.isActive = false
+            leftStackViewLeadingConstraint?.isActive = true
+        }
+    }
+    
+    private func removeBarButtons() {
+        leftNavBarItemStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        rightNavBarItemStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+    }
+    
+    private func configBarButtons() {
+        switch barType {
+        case .pushed:
+            leftNavBarItemStackView.addArrangedSubview(leftBarBackButton)
+                
+        case .leftCloseButton:
+            leftNavBarItemStackView.addArrangedSubview(leftBarCloseButton)
             
         case .rightCloseButton:
-            rightBarButton.setImage(image, for: .normal)
-            rightNavBarItemStackView.addArrangedSubview(rightBarButton)
+            rightNavBarItemStackView.addArrangedSubview(rightBarCloseButton)
         }
     }
 
@@ -112,7 +127,6 @@ final class DWNavBarView: DWBaseView {
     
     override func configLayoutConstraints() {
         NSLayoutConstraint.activate([
-            leftNavBarItemStackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
             leftNavBarItemStackView.centerYAnchor.constraint(equalTo: centerYAnchor),
             leftNavBarItemStackView.topAnchor.constraint(equalTo: topAnchor),
             leftNavBarItemStackView.bottomAnchor.constraint(equalTo: bottomAnchor),

--- a/Sources/DWDesignKit/Component/DWNavBar.swift
+++ b/Sources/DWDesignKit/Component/DWNavBar.swift
@@ -7,26 +7,7 @@
 
 import UIKit
 
-public enum DWNavBarType {
-    case pushed
-    case leftCloseButton
-    case rightCloseButton
-    
-    var imageConfig: UIImage.SymbolConfiguration {
-        switch self {
-        case .pushed:
-            return UIImage.SymbolConfiguration(pointSize: 22, weight: .semibold)
-            
-        case .leftCloseButton:
-            return UIImage.SymbolConfiguration(pointSize: 17, weight: .semibold)
-            
-        case .rightCloseButton:
-            return UIImage.SymbolConfiguration(pointSize: 17, weight: .semibold)
-        }
-    }
-}
-
-public final class DWNavBarView: DWBaseView {
+final class DWNavBarView: DWBaseView {
     
     private var leftNavBarItemStackView: UIStackView = {
         let stackView = UIStackView()
@@ -48,13 +29,13 @@ public final class DWNavBarView: DWBaseView {
         return stackView
     }()
     
-    public var leftBarButton: UIButton = {
+    var leftBarButton: UIButton = {
         let button = UIButton()
         
         return button
     }()
     
-    public var rightBarButton: UIButton = {
+    var rightBarButton: UIButton = {
         let button = UIButton()
         
         return button
@@ -69,26 +50,26 @@ public final class DWNavBarView: DWBaseView {
         return label
     }()
     
-    public var titleText: String? {
+    var titleText: String? {
         didSet {
             titleLabel.text = titleText
         }
     }
     
-    public var titleColor: UIColor? {
+    var titleColor: UIColor? {
         didSet {
             titleLabel.textColor = titleColor
         }
     }
     
-    public var buttonColor: UIColor? {
+    var buttonColor: UIColor? {
         didSet {
             leftBarButton.tintColor = buttonColor
             rightBarButton.tintColor = buttonColor
         }
     }
     
-    public var barHeight: CGFloat = 44 {
+    var barHeight: CGFloat = 44 {
         didSet {
             if barHeight < 44 { barHeight = 44 }
             heightAnchor.constraint(equalToConstant: barHeight).isActive = true
@@ -96,36 +77,33 @@ public final class DWNavBarView: DWBaseView {
     }
     
     func configBarButtons(_ type: DWNavBarType) {
-        let config = type.imageConfig
+        let config = UIImage.SymbolConfiguration(pointSize: type.imageSize, weight: .semibold)
+        let image = UIImage(systemName: type.systemImageName, withConfiguration: config)
         
         switch type {
-        case .pushed:
-            leftBarButton.setImage(UIImage(systemName: "chevron.left", withConfiguration: config), for: .normal)
-            leftNavBarItemStackView.addArrangedSubview(leftBarButton)
-            
-        case .leftCloseButton:
-            leftBarButton.setImage(UIImage(systemName: "xmark", withConfiguration: config), for: .normal)
+        case .pushed, .leftCloseButton:
+            leftBarButton.setImage(image, for: .normal)
             leftNavBarItemStackView.addArrangedSubview(leftBarButton)
             
         case .rightCloseButton:
-            rightBarButton.setImage(UIImage(systemName: "xmark", withConfiguration: config), for: .normal)
+            rightBarButton.setImage(image, for: .normal)
             rightNavBarItemStackView.addArrangedSubview(rightBarButton)
         }
     }
 
-    public override func configViewSettings() {
+    override func configViewSettings() {
         [leftNavBarItemStackView, rightNavBarItemStackView, titleLabel].forEach {
             $0.translatesAutoresizingMaskIntoConstraints = false
         }
     }
     
-    public override func configViewHierarchy() {
+    override func configViewHierarchy() {
         addSubview(leftNavBarItemStackView)
         addSubview(rightNavBarItemStackView)
         addSubview(titleLabel)
     }
     
-    public override func configLayoutConstraints() {
+    override func configLayoutConstraints() {
         NSLayoutConstraint.activate([
             leftNavBarItemStackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
             leftNavBarItemStackView.centerYAnchor.constraint(equalTo: centerYAnchor),

--- a/Sources/DWDesignKit/Component/DWNavBar.swift
+++ b/Sources/DWDesignKit/Component/DWNavBar.swift
@@ -72,7 +72,14 @@ final class DWNavBarView: DWBaseView {
     var barHeight: CGFloat = 44 {
         didSet {
             if barHeight < 44 { barHeight = 44 }
-            heightAnchor.constraint(equalToConstant: barHeight).isActive = true
+            barHeightAnchor = heightAnchor.constraint(equalToConstant: barHeight)
+        }
+    }
+    
+    private var barHeightAnchor: NSLayoutConstraint? {
+        didSet {
+            oldValue?.isActive = false
+            barHeightAnchor?.isActive = true
         }
     }
     

--- a/Sources/DWDesignKit/Component/DWNavBar.swift
+++ b/Sources/DWDesignKit/Component/DWNavBar.swift
@@ -80,11 +80,6 @@ final class DWNavBarView: DWBaseView {
         didSet {
             removeBarButtons()
             configBarButtons()
-            
-            leftStackViewLeadingConstraint = leftNavBarItemStackView.leadingAnchor.constraint(
-                equalTo: leadingAnchor, 
-                constant: barType.leadingInset
-            )
         }
     }
     
@@ -127,11 +122,12 @@ final class DWNavBarView: DWBaseView {
     
     override func configLayoutConstraints() {
         NSLayoutConstraint.activate([
+            leftNavBarItemStackView.leadingAnchor.constraint(equalTo: leadingAnchor),
             leftNavBarItemStackView.centerYAnchor.constraint(equalTo: centerYAnchor),
             leftNavBarItemStackView.topAnchor.constraint(equalTo: topAnchor),
             leftNavBarItemStackView.bottomAnchor.constraint(equalTo: bottomAnchor),
             
-            rightNavBarItemStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+            rightNavBarItemStackView.trailingAnchor.constraint(equalTo: trailingAnchor),
             rightNavBarItemStackView.centerYAnchor.constraint(equalTo: centerYAnchor),
             rightNavBarItemStackView.topAnchor.constraint(equalTo: topAnchor),
             rightNavBarItemStackView.bottomAnchor.constraint(equalTo: bottomAnchor),

--- a/Sources/DWDesignKit/Component/DWNavBarButton.swift
+++ b/Sources/DWDesignKit/Component/DWNavBarButton.swift
@@ -26,5 +26,22 @@ final class DWNavBarButton: UIButton {
         let config = UIImage.SymbolConfiguration(pointSize: type.imageSize, weight: .semibold)
         let image = UIImage(systemName: type.systemImageName, withConfiguration: config)
         setImage(image, for: .normal)
+        
+        contentEdgeInsets = UIEdgeInsets(top: 0, left: type.leadingInset, bottom: 0, right: type.trailingInset)
+        configContentAlignment()
+        
+        translatesAutoresizingMaskIntoConstraints = false
+        heightAnchor.constraint(equalToConstant: 44).isActive = true
+        widthAnchor.constraint(equalToConstant: 44).isActive = true
+    }
+    
+    private func configContentAlignment() {
+        switch type {
+        case .pushed, .leftCloseButton:
+            contentHorizontalAlignment = .leading
+            
+        case .rightCloseButton:
+            contentHorizontalAlignment = .trailing
+        }
     }
 }

--- a/Sources/DWDesignKit/Component/DWNavBarButton.swift
+++ b/Sources/DWDesignKit/Component/DWNavBarButton.swift
@@ -1,0 +1,30 @@
+//
+//  DWNavBarButton.swift
+//
+//
+//  Created by Eunbee Kang on 3/21/24.
+//
+
+import UIKit
+
+final class DWNavBarButton: UIButton {
+        
+    private var type: DWNavBarType
+    
+    init(type: DWNavBarType) {
+        self.type = type
+        super.init(frame: .zero)
+        
+        configButton()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func configButton() {
+        let config = UIImage.SymbolConfiguration(pointSize: type.imageSize, weight: .semibold)
+        let image = UIImage(systemName: type.systemImageName, withConfiguration: config)
+        setImage(image, for: .normal)
+    }
+}

--- a/Sources/DWDesignKit/Model/DWNavBarType.swift
+++ b/Sources/DWDesignKit/Model/DWNavBarType.swift
@@ -1,0 +1,34 @@
+//
+//  DWNavBarType.swift
+//  
+//
+//  Created by Eunbee Kang on 3/21/24.
+//
+
+import Foundation
+
+public enum DWNavBarType {
+    case pushed
+    case leftCloseButton
+    case rightCloseButton
+    
+    var imageSize: CGFloat {
+        switch self {
+        case .pushed:
+            return 22
+            
+        case .leftCloseButton, .rightCloseButton:
+            return 17
+        }
+    }
+    
+    var systemImageName: String {
+        switch self {
+        case .pushed:
+            return "chevron.left"
+            
+        case .leftCloseButton, .rightCloseButton:
+            return "xmark"
+        }
+    }
+}

--- a/Sources/DWDesignKit/Model/DWNavBarType.swift
+++ b/Sources/DWDesignKit/Model/DWNavBarType.swift
@@ -31,4 +31,14 @@ public enum DWNavBarType {
             return "xmark"
         }
     }
+    
+    var leadingInset: CGFloat {
+        switch self {
+        case .pushed:
+            return 8
+            
+        case .leftCloseButton, .rightCloseButton:
+            return 16
+        }
+    }
 }

--- a/Sources/DWDesignKit/Model/DWNavBarType.swift
+++ b/Sources/DWDesignKit/Model/DWNavBarType.swift
@@ -34,11 +34,17 @@ public enum DWNavBarType {
     
     var leadingInset: CGFloat {
         switch self {
-        case .pushed:
-            return 8
-            
-        case .leftCloseButton, .rightCloseButton:
-            return 16
+        case .pushed: return 8
+        case .leftCloseButton: return 16
+        case .rightCloseButton: return 0
+        }
+    }
+    
+    var trailingInset: CGFloat {
+        switch self {
+        case .pushed: return 0
+        case .leftCloseButton: return 0
+        case .rightCloseButton: return 16
         }
     }
 }

--- a/Sources/DWDesignKit/Utility/Extension/DWBaseViewController+Extension.swift
+++ b/Sources/DWDesignKit/Utility/Extension/DWBaseViewController+Extension.swift
@@ -9,7 +9,6 @@ import UIKit
 
 extension DWBaseViewController {
     
-    @available(iOS 13.0, *)
     public func showActivityIndicator(
         indicatorColor: UIColor = .white,
         indicatorStyle: UIActivityIndicatorView.Style = .large,

--- a/Sources/DWDesignKit/Utility/Extension/Reactive+Extension.swift
+++ b/Sources/DWDesignKit/Utility/Extension/Reactive+Extension.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  Reactive+Extension.swift
 //  
 //
 //  Created by Eunbee Kang on 3/19/24.
@@ -12,7 +12,6 @@ import RxSwift
 
 extension Reactive where Base: DWBaseViewController {
     
-    @available(iOS 13.0, *)
     public var isShowingActivityIndicator: Binder<Bool> {
         return Binder(base) { (base, value) in
             value ? base.showActivityIndicator() : base.hideActivityIndicator()

--- a/Sources/DWDesignKit/Utility/ReusableViewProtocol.swift
+++ b/Sources/DWDesignKit/Utility/ReusableViewProtocol.swift
@@ -1,0 +1,30 @@
+//
+//  ReusableViewProtocol.swift
+//
+//
+//  Created by Eunbee Kang on 3/21/24.
+//
+
+import UIKit
+
+public protocol ReusableViewProtocol {
+    static var reuseIdentifier: String { get }
+}
+
+extension DWBaseViewController: ReusableViewProtocol {
+    public static var reuseIdentifier: String {
+        return String(describing: self)
+    }
+}
+
+extension DWBaseTableViewCell: ReusableViewProtocol {
+    public static var reuseIdentifier: String {
+        return String(describing: self)
+    }
+}
+
+extension DWBaseCollectionViewCell: ReusableViewProtocol {
+    public static var reuseIdentifier: String {
+        return String(describing: self)
+    }
+}


### PR DESCRIPTION
### 주요사항
- `DWBaseViewController`를 상속한 `DWBaseNavBarViewController`를 추가했습니다.
    - 기본적으로 네이티브 navigationBar는 hidden 처리되며, 커스텀 네비게이션바가 보입니다.
    - 배경 색상, 타이틀 텍스트, 타이틀 색상, 바 높이(기본 44), 스와이프하여 뒤로가기 여부를 설정할 수 있습니다.
    - 버튼 종류/위치에 따라 세 가지 타입을 가집니다: 1. 왼쪽 뒤로가기 버튼, 2. 왼쪽 닫기 버튼, 3. 오른쪽 닫기 버튼
    - 뷰 구성 시 `contentView` 프로퍼티에 `addSubview`로 요소를 추가해야 합니다.

### 기타 수정사항
- 패키지 적용가능한 플랫폼과 최소버전을 iOS 13으로 설정했습니다.
- `DWBaseViewController`의 기본 배경색을 `systemBackground`로 설정했습니다.
- 테이블뷰셀의 `selectionStyle`을 `.none`으로 설정했습니다.
- 뷰컨트롤러, 테이블뷰셀, 컬렉션뷰셀에 타입 프로퍼티 `reuseIdentifier`를 추가했습니다.